### PR TITLE
Convert prep_ref to its own workflow

### DIFF
--- a/utils/reference_prep.cwl
+++ b/utils/reference_prep.cwl
@@ -1,0 +1,38 @@
+cwlVersion: v1.0
+class: Workflow
+id: reference file prep
+
+requirements:
+  - class: StepInputExpressionRequirement
+
+inputs: 
+    zipped:
+        type: File
+
+steps:
+    unzip_ref:
+        run: ./utils/gzip.cwl
+        in:
+            zipped: zipped
+        out:
+            - unzipped
+    index_ref:
+        run: ./utils/fai.cwl
+        in:
+            to_index: unzip_ref/unzipped
+        out:
+            - faidx
+    dict_ref:
+        run: ./utils/dict.cwl
+        in:
+            to_dict: index_ref/faidx
+        out:
+            - dict
+
+outputs:
+    prepped_ref:
+        type: File
+        secondaryFiles:
+            - ^.fai
+            - .dict
+        outputSource: dict_ref/dict


### PR DESCRIPTION
Pulled prep_ref step from mc3_variant.cwl and made it a standalone workflow